### PR TITLE
Escape markdown chars

### DIFF
--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -5,7 +5,8 @@ function TrimAllLines([string] $str) {
 		$lines[$i] = $lines[$i].Trim()
 	}
 
-	$lines | Out-String | Write-Output
+	# Trim EOL.
+	($lines | Out-String).Trim()
 }
 
 function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
@@ -32,7 +33,7 @@ function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
 		$rtn = $rtn.Replace($key, $replacements[$key])
 	}
 
-	if($includeBreaks) {
+	if ($includeBreaks) {
 		$rtn = $rtn.Replace([Environment]::NewLine, "  `n")
 	}
 	TrimAllLines $rtn

--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -1,4 +1,4 @@
-function FixMarkdownString($in = '', [bool]$includeBreaks = $false) {
+function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
 	if ($in -eq $null) { return }
 
 	$replacements = @{
@@ -17,15 +17,20 @@ function FixMarkdownString($in = '', [bool]$includeBreaks = $false) {
 		'!' = '\!'
 	}
 
-	$rtn = $in
+	$rtn = $in.Trim()
 	foreach ($key in $replacements.Keys) {
 		$rtn = $rtn.Replace($key, $replacements[$key])
 	}
 
-	if($includeBreaks){
+	if($includeBreaks) {
 		$rtn = $rtn.Replace([Environment]::NewLine, "  `n")
 	}
-	return $rtn
+	$rtn
+}
+
+function FixMarkdownCodeString([string] $in) {
+	if ($in -eq $null) { return }
+	$in.Trim()
 }
 
 @"
@@ -134,9 +139,9 @@ $notes
 @"
 **$(FixMarkdownString($_.title.Trim(('-',' '))))**
 
-		$(FixMarkdownString($_.code | out-string ))
+		$(FixMarkdownCodeString($_.code | out-string ))
 		
-$(FixMarkdownString($_.remarks | out-string ))
+$(FixMarkdownString($_.remarks | out-string ) $true)
 "@
 		}
 	}

--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -14,8 +14,6 @@ function FixMarkdownString($in = '', [bool]$includeBreaks = $false) {
 		')' = '\)'
 		'#' = '\#'
 		'+' = '\+'
-		'-' = '\-'
-		'.' = '\.'
 		'!' = '\!'
 	}
 

--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -36,7 +36,8 @@ function FixMarkdownString([string] $in = '', [bool] $includeBreaks = $false) {
 	$rtn = TrimAllLines $rtn
 
 	if ($includeBreaks) {
-		$rtn = $rtn.Replace([Environment]::NewLine, "  `n")
+		$crlf = [Environment]::NewLine
+		$rtn = $rtn.Replace($crlf, "  $crlf")
 	}
 	$rtn
 }

--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -1,3 +1,13 @@
+function TrimAllLines([string] $str) {
+	$lines = $str -split "`n"
+
+	for ($i = 0; $i -lt $lines.Count; $i++) {
+		$lines[$i] = $lines[$i].Trim()
+	}
+
+	$lines | Out-String | Write-Output
+}
+
 function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
 	if ($in -eq $null) { return }
 
@@ -25,12 +35,13 @@ function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
 	if($includeBreaks) {
 		$rtn = $rtn.Replace([Environment]::NewLine, "  `n")
 	}
-	$rtn
+	TrimAllLines $rtn
 }
 
 function FixMarkdownCodeString([string] $in) {
 	if ($in -eq $null) { return }
-	$in.Trim()
+	
+	TrimAllLines $in
 }
 
 @"

--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -9,7 +9,7 @@ function TrimAllLines([string] $str) {
 	($lines | Out-String).Trim()
 }
 
-function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
+function FixMarkdownString([string] $in = '', [bool] $includeBreaks = $false) {
 	if ($in -eq $null) { return }
 
 	$replacements = @{
@@ -33,10 +33,12 @@ function FixMarkdownString([string] $in = '', [bool]$includeBreaks = $false) {
 		$rtn = $rtn.Replace($key, $replacements[$key])
 	}
 
+	$rtn = TrimAllLines $rtn
+
 	if ($includeBreaks) {
 		$rtn = $rtn.Replace([Environment]::NewLine, "  `n")
 	}
-	TrimAllLines $rtn
+	$rtn
 }
 
 function FixMarkdownCodeString([string] $in) {

--- a/src/out-markdown-template.ps1
+++ b/src/out-markdown-template.ps1
@@ -1,3 +1,35 @@
+function FixMarkdownString($in = '', [bool]$includeBreaks = $false) {
+	if ($in -eq $null) { return }
+
+	$replacements = @{
+		'\' = '\\'
+		'`' = '\`'
+		'*' = '\*'
+		'_' = '\_'
+		'{' = '\{'
+		'}' = '\}'
+		'[' = '\['
+		']' = '\]'
+		'(' = '\('
+		')' = '\)'
+		'#' = '\#'
+		'+' = '\+'
+		'-' = '\-'
+		'.' = '\.'
+		'!' = '\!'
+	}
+
+	$rtn = $in
+	foreach ($key in $replacements.Keys) {
+		$rtn = $rtn.Replace($key, $replacements[$key])
+	}
+
+	if($includeBreaks){
+		$rtn = $rtn.Replace([Environment]::NewLine, "  `n")
+	}
+	return $rtn
+}
+
 @"
 # $moduleName
 "@
@@ -6,7 +38,7 @@ $commandsHelp | % {
 	Update-Progress $_.Name 'Documentation'
 	$progress++
 @"
-## $(FixString($_.Name))
+## $(FixMarkdownString($_.Name))
 "@
 	$synopsis = $_.synopsis.Trim()
 	$syntax = $_.syntax | out-string
@@ -16,12 +48,12 @@ $commandsHelp | % {
 		$syntax = $tmp
 @"	
 ### Synopsis
-$(FixString($syntax))
+$(FixMarkdownString($syntax))
 "@
 	}
 @"	
 ### Syntax
-$(FixString($synopsis))
+$(FixMarkdownString($synopsis))
 "@	
 
 	if (!($_.alias.Length -eq 0)) {
@@ -38,7 +70,7 @@ $(FixString($synopsis))
 "@
 	}
 	
-    if($_.parameters){
+	if($_.parameters){
 @"
 ### Parameters
 
@@ -55,41 +87,41 @@ $(FixString($synopsis))
 	</thead>
 	<tbody>
 "@
-        $_.parameters.parameter | % {
+		$_.parameters.parameter | % {
 @"
 		<tr>
-			<td><nobr>$(FixString($_.Name))</nobr></td>
-			<td class="visible-lg visible-md">$(FixString($_.Aliases))</td>
-			<td>$(FixString(($_.Description  | out-string).Trim()) $true)</td>
-			<td class="visible-lg visible-md">$(FixString($_.Required))</td>
-			<td class="visible-lg">$(FixString($_.PipelineInput))</td>
-			<td class="visible-lg">$(FixString($_.DefaultValue))</td>
+			<td><nobr>$(FixMarkdownString($_.Name))</nobr></td>
+			<td class="visible-lg visible-md">$(FixMarkdownString($_.Aliases))</td>
+			<td>$(FixMarkdownString(($_.Description  | out-string).Trim()) $true)</td>
+			<td class="visible-lg visible-md">$(FixMarkdownString($_.Required))</td>
+			<td class="visible-lg">$(FixMarkdownString($_.PipelineInput))</td>
+			<td class="visible-lg">$(FixMarkdownString($_.DefaultValue))</td>
 		</tr>
 "@
-        }
+		}
 @"
 	</tbody>
 </table>			
 "@
-    }
-    $inputTypes = $(FixString($_.inputTypes  | out-string))
-    if ($inputTypes.Length -gt 0 -and -not $inputTypes.Contains('inputType')) {
+	}
+	$inputTypes = $(FixMarkdownString($_.inputTypes  | out-string))
+	if ($inputTypes.Length -gt 0 -and -not $inputTypes.Contains('inputType')) {
 @"
 ### Inputs
  - $inputTypes
 
 "@
 	}
-    $returnValues = $(FixString($_.returnValues  | out-string))
-    if ($returnValues.Length -gt 0 -and -not $returnValues.StartsWith("returnValue")) {
+	$returnValues = $(FixMarkdownString($_.returnValues  | out-string))
+	if ($returnValues.Length -gt 0 -and -not $returnValues.StartsWith("returnValue")) {
 @"
 ### Outputs
  - $returnValues
 
 "@
 	}
-    $notes = $(FixString($_.alertSet  | out-string))
-    if ($notes.Trim().Length -gt 0) {
+	$notes = $(FixMarkdownString($_.alertSet  | out-string))
+	if ($notes.Trim().Length -gt 0) {
 @"
 ### Note
 $notes
@@ -102,11 +134,11 @@ $notes
 "@
 		$_.examples.example | % {
 @"
-**$(FixString($_.title.Trim(('-',' '))))**
+**$(FixMarkdownString($_.title.Trim(('-',' '))))**
 
-		$(FixString($_.code | out-string ))
+		$(FixMarkdownString($_.code | out-string ))
 		
-$(FixString($_.remarks | out-string ))
+$(FixMarkdownString($_.remarks | out-string ))
 "@
 		}
 	}


### PR DESCRIPTION
This pull-request enhances formatting of Markdown output for EXAMPLE and NOTES sections.

It removes unwanted indentation and escapes special characters to prevent unwanted formatting.

```
<#
.EXAMPLE
Write-Something 'Hello'

# File1.ps1
Write-Something 'Hello, '

# File2.ps1
Write-Something 'World'
.NOTES
Notes line 1.
Notes line 2.
Notes line 3.

Paragraph 2.

Paragraph 3.
#>
function Write-Something([string] $Message)
{
}
```

![2016-10-20_2233](https://cloud.githubusercontent.com/assets/4054844/19567346/83d0d92c-9717-11e6-81ea-b098ca07aa2f.png)
![2016-10-20_2243](https://cloud.githubusercontent.com/assets/4054844/19567351/88a04fd2-9717-11e6-8f31-d1b75abdf840.png)
